### PR TITLE
Add project donation policy

### DIFF
--- a/project-donation.md
+++ b/project-donation.md
@@ -1,0 +1,86 @@
+# Project Donation Policy Draft
+
+This document describes how specific projects from outside an organization can
+move under a unified collective organization.
+It’s a guide for organization teams to follow, but they are free in defining
+their own project donation policy instead.
+
+This document is developed by the unified collective core team.
+
+## Summary
+
+## Table of Contents
+
+*   [Glossary](#glossary)
+*   [Applicable Projects](#applicable-projects)
+*   [Donation procedure](#donation-procedure)
+*   [Outside collaborators](#outside-collaborators)
+*   [License](#license)
+
+## Glossary
+
+*   **org**
+    — unified organization team
+*   **inside project**
+    — project maintained by an **org**
+*   **outside project**
+    — project maintained outside of an **org**
+*   **member**
+    — active member of an **org**
+*   **outside maintainer**
+    — individual who maintains an **outside project**
+*   **outside collaborator**
+    — non-member who donated an **outside project** to an **org**
+
+## Applicable Projects
+
+Organization teams maintain several plugins, utilities, or other projects
+around their area of expertise.
+Such projects can also be maintained outside of an organization: anyone can
+develop, maintain, and self-govern projects.
+
+Outside projects can flourish, but sometimes they could benefit from being
+inside the organization.
+Signs of this are for example that issues are left unanswered or that
+dependencies are outdated.
+
+These applicable outside projects can become inside projects, in which case
+they are moved under the governance of an organization team.
+
+## Donation procedure
+
+*   Optionally, a **member** may contact an **outside maintainer** to suggest
+    donating an applicable **outside project** to an **org**.
+    Members may of course also nominate outside collaborators for membership.
+    An **outside maintainer** may decline this suggestion
+*   An **outside maintainer** may nominate a project they administer for
+    donation on the organization’s governance repository (e.g.,
+    `remarkjs/governance`).
+*   **Members** must review whether adopting the project makes sense and whether
+    they accept governance over the repository.
+    Provided there are no objections from the members, such requests are
+    approved automatically after 72 hours.
+    If any objection is made, the request may be moved to a majority vote in
+    the core team.
+    If the vote rejects the request the donation is denied.
+*   The **outside maintainer** should add a **member** to the **outside
+    project** on GitHub and npm.
+*   The **member** will move the project, strip **outside maintainers** of
+    their release rights, and configure them as **outside collaborators**.
+*   **Member**s or **outside collaborators** should make sure the project
+    matches **inside projects**, such as having a “Contributing” section,
+    a proper license, etc.
+
+## Outside collaborators
+
+The rights and responsibilities of outside collaborators are described in
+`governance.md`.
+
+## License
+
+This work is licensed under a
+[Creative Commons Attribution 4.0 International License][license].
+
+<!-- definitions -->
+
+[license]: https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
_Rendered version: https://github.com/unifiedjs/governance/blob/project-donation/project-donation.md_

👋 Another day another policy! 👩🏽‍💼

This document describes a suggested flow for how projects can be donated / adopted by an organization. It relates to GH-2, GH-5, and an as-of-yet non-existing npm policy.

I think the makes a lot of sense, but there’s one big talking point: I suggest stripping release rights from outside collaborators because npm is really hard to check (it’s easy to add some code at the end of a file and publish it without anyone knowing, and as we have so many tiny projects, and if we’d allow anyone to keep these rights, it’s a big attack vector).

Now, my mind’s not made up, but maybe y’all have some good ideas on this!

@unifiedjs/core could you review this?

@kmck, @dherges, @vweevers, @denysdovhan as you are all outside collaborators, what are your thoughts on this?