### PR TITLE
Adding the Contributor Covenant Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at richard@maintainer.io, which will go only to Richard Littauer, or to liv@fastmail.com, which will go only to Olivia Hugger. You may also cc both. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,6 +65,8 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
+In cases where community members transgress against the values in the Code, members of the Moderation team will use a three-strike warning system, where the aggressor will be warned twice before they are permanently excluded from our community spaces. This code applies to Spectrum, IRC, and GitHub, and any other space that this community uses for communication. For interactions between community members outside of this space, the code also applies if the interactions are reported and deemed to be interfering with community members safely working on any project together. Conversations between moderators (when they are more serious than discussing simple warnings) will occur in private repositories or through email, to ensure both anonymity for reporters and the safety of the moderators.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -55,25 +55,36 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at richard@maintainer.io, which will go only to Richard Littauer, or to liv@fastmail.com, which will go only to Olivia Hugger. You may also cc both. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the project team at richard@maintainer.io, which will go
+only to Richard Littauer, or to liv@fastmail.com, which will go only to Olivia
+Hugger. You may also cc both. All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary and appropriate to the
+circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-In cases where community members transgress against the values in the Code, members of the Moderation team will use a three-strike warning system, where the aggressor will be warned twice before they are permanently excluded from our community spaces. This code applies to Spectrum, IRC, and GitHub, and any other space that this community uses for communication. For interactions between community members outside of this space, the code also applies if the interactions are reported and deemed to be interfering with community members safely working on any project together. Conversations between moderators (when they are more serious than discussing simple warnings) will occur in private repositories or through email, to ensure both anonymity for reporters and the safety of the moderators.
+In cases where community members transgress against the values in the Code,
+members of the Moderation team will use a three-strike warning system, where the
+aggressor will be warned twice before they are permanently excluded from our
+community spaces. This code applies to Spectrum, IRC, and GitHub, and any other
+space that this community uses for communication. For interactions between
+community members outside of this space, the code also applies if the
+interactions are reported and deemed to be interfering with community members
+safely working on any project together. Conversations between moderators (when
+they are more serious than discussing simple warnings) will occur in private
+repositories or through email, to ensure both anonymity for reporters and the
+safety of the moderators.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
-

--- a/readme.md
+++ b/readme.md
@@ -452,6 +452,9 @@ not include **[core team][core]** members.
 *   Olivia Hugger
     ([**@komaeda**](https://github.com/komaeda))
     &lt;liv@fastmail.com>
+*   Richard Littauer
+    ([**@RichardLitt**](https://github.com/RichardLitt))
+    &lt;richard@maintainer.io>
 
 ## Glossary
 
@@ -474,6 +477,12 @@ not projects in the sense that they include code.
 
 An initiative is a non-trivial change that significantly affects users.
 Teams must define what they deem **trivial** or **significant**.
+
+## Code of Conduct
+
+We follow the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). Please read it at your leisure, as you agree to abide by it by interacting with @unifiedjs on GitHub.
+
+This Code should be copied to all documentation repositories for each project, and applies to every repository in the wider @unifiedjs ecosystem.
 
 ## License
 


### PR DESCRIPTION
See #6. I think that this PR should add it here, and then that we should add it to the other main documentation repositories. I did not see the need to use a different CoC - I think this one should do fine. Note that I also added myself to the moderation team, because I do not like having only one person on it, and I am happy to do this work as needed.

@komaeda what do you think?