### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2019-05-31-wooorm.md
+++ b/invoices/2019-05-31-wooorm.md
@@ -1,0 +1,17 @@
+# Invoice: unified collective
+
+*   **Date**: 2019-05-31
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+*   **Rate**: $40/hr (non-profit, open source discount)
+
+## Items
+
+| Item               | Description                   | Hours | Total         |
+| ------------------ | ----------------------------- | ----- | ------------- |
+| unified collective | Development and support (May) | 110   | **$4,400.00** |
+
+* * *
+
+*   **Commits**: [2106](https://github.com/search?o=desc&q=author%3Awooorm+committer-date%3A%222019-05-01..2019-06-01%22&s=author-date&type=Commits)
+*   **Issues and PRs**: [42](https://github.com/search?o=desc&q=author%3Awooorm+created%3A%222019-05-01..2019-06-01%22&s=created&type=Issues)
+*   **Reviews**: [14](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-05-01..2019-06-01%22&s=created&type=Issues)


### PR DESCRIPTION
Hi friends!  👋

This month (May 5 to May 31) I started full time OSS!  ✨ I got a bit excited and have been putting in a lot of time, more than I think I could keep up with in the future or is healthy, but it’s been nice to clean up this garden: I’ve updated the things under @wooorm, @words, @syntax-tree, and @vfile, which took 2.1K commits (note that the first two are not part of unified but do significantly affect the collective as those projects are often dependencies).

It’s a good feeling to finally get a lot of things done. I’m not stressed about all the open issues (108) anymore because that number is slowly decreasing. I have more time for support on Spectrum and I’ve noticed by responses getting a bit nicer due to the reduced stress.

I am stressed about the fact that we don’t have enough money to sustain a full time person. $4,420.83 leaves me with €1.941,79 after taxes and then there’s rent. 😐

### 🕴🏼 Hours / Rate

I didn’t keep track of time, but looking back I estimate it took about 250 to 300 hours.  Now, invoicing that amount of hours, with a discount rate for OSS at about $40 an hour is not going to work of course. So instead I’ve done the following calculation:

#### 🤓 Algorithm

*   Let `fee` be the payment processor fee (4.51%)
*   Let `annual` be the current OC Estimated Annual Budget ($26,392.00) reduced
    by `fee` ($25,201.72)
*   Let `balance` be the current OC Today’s Balance ($14,581.75) reduced by
    `fee` ($13,924.11)
*   Let `monthly` be `annual` divided by 12 ($2,100.14)
*   Let `balanceUse` be `balance` divided by 6 ($2,320.69)
*   Let `total` be the sum of `monthly` and `balanceUse` ($4,420.83)

This boils down to an hourly rate of $14.74 to $17.68.

> (note: on the open collective invoice I instead capped the hours to 110 at a rate of $40 to get an amount of $4400)

### ✅ May

#### 📊 Numbers

*   **Commits**: [2106](https://github.com/search?o=desc&q=author%3Awooorm+committer-date%3A%222019-05-01..2019-06-01%22&s=author-date&type=Commits)
*   **Issues and PRs**: [42](https://github.com/search?o=desc&q=author%3Awooorm+created%3A%222019-05-01..2019-06-01%22&s=created&type=Issues)
*   **Reviews**: [14](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-05-01..2019-06-01%22&s=created&type=Issues)

#### 🧹 Greenkeeping

Most time spent went into cleaning this garden 🌻 of 250 collective projects.

* Repo’s updated under the collective: 105 (89 + 16)
* Repo’s not yet updated under the collective: 112 (48 + 24 + 14 + 15 + 7 + 4)
* Repo’s updated outside of the collective: 138 (107 + 31)

#### ✨ Highlights

* Created [`syntax-tree/.github`](https://github.com/syntax-tree/github) and [`vfile/.github`](https://github.com/vfile/.github) to house community health files. We now have a new support document, funding.yml, pull request template, and issue templates
* [`syntax-tree/awesome-syntax-tree`](https://github.com/syntax-tree/awesome-syntax-tree)
* [`syntax-tree/hast-util-to-text`@1.0.0](https://github.com/syntax-tree/hast-util-to-text) (this was like a week of work)
* [`syntax-tree/hast-util-to-mdast`@5.0.0](https://github.com/syntax-tree/hast-util-to-mdast/releases) (even supporting [straddled paragraphs](https://github.com/syntax-tree/hast-util-to-mdast/pull/51) and [forms](https://github.com/syntax-tree/hast-util-to-mdast/pull/50))
* [`syntax-tree/hast-util-to-dom`@2.0.0](https://github.com/syntax-tree/hast-util-to-dom/releases/tag/2.0.0) and [`syntax-tree/hast-util-from-dom`@2.0.0](https://github.com/syntax-tree/hast-util-from-dom/releases/tag/2.0.0)
* wrote about [tree traversal](https://github.com/syntax-tree/unist#tree-traversal) in [`syntax-tree/unist`](https://github.com/syntax-tree/unist)
* No open issues / PRs in vfile / syntax-tree except for vague concepts and /ideas

#### 🤷‍♂️ Other things

* 🧶 I’ve started knitting 👵🏼
* 😅 I ran my first half marathon (1:41:22) 🏃🏻‍♂️

### 🗓 June

In June I want to update the other 112 not yet updated repos under the collective with health files, badges, and better docs.
I want to decrease the [number of open issues](https://github.com/search?o=desc&q=user%3Awooorm+user%3Amdx-js+user%3Amicromark+user%3Aremarkjs+user%3Arehypejs+user%3Aretextjs+user%3Aunifiedjs+user%3Asyntax-tree+user%3Avfile+user%3Aget-alex+user%3Awords+is%3Aopen+-author%3Awooorm+-repo%3Asyntax-tree%2Fideas+-repo%3Aremarkjs%2Fideas+-repo%3Arehypejs%2Fideas+-repo%3Aretextjs%2Fideas+-repo%3Aunifiedjs%2Fideas+-repo%3Avfile%2Fideas&s=created&type=Issues) further.

### 🚀 Future

After everything’s updated, I’ll have time to work on [org tooling](https://github.com/unifiedjs/rfcs/pull/1), more policies, the rest of the open issues, restarting micromark, and perhaps most importantly: getting more sponsors.
