### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2019-07-01-wooorm.md
+++ b/invoices/2019-07-01-wooorm.md
@@ -1,0 +1,17 @@
+# Invoice: unified collective
+
+*   **Date**: 2019-07-01
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+*   **Rate**: $40/hr (non-profit, open source discount)
+
+## Items
+
+| Item               | Description                    | Hours | Total         |
+| ------------------ | ------------------------------ | ----- | ------------- |
+| unified collective | Development and support (June) | 108   | **$4,320.00** |
+
+* * *
+
+*   **Commits**: [908](https://github.com/search?o=desc&q=author%3Awooorm+committer-date%3A%222019-06-01..2019-07-01%22&s=author-date&type=Commits)
+*   **Issues and PRs**: [29](https://github.com/search?o=desc&q=author%3Awooorm+created%3A%222019-06-01..2019-07-01%22&s=created&type=Issues)
+*   **Reviews**: [20](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-06-01..2019-07-01%22&s=created&type=Issues)


### PR DESCRIPTION
Hi friends!  👋

This month (June 1 to June 30) was my second month of full time OSS!  I worked on @retextjs, @rehypejs, @remarkjs, and @unifiedjs.  I made 900 commits and 29 issues/PRs.

The number of big open issues is decreasing.  There’s about [44 left](https://github.com/search?q=user%3Amicromark+user%3Aremarkjs+user%3Arehypejs+user%3Aretextjs+user%3Aunifiedjs+user%3Asyntax-tree+user%3Avfile+is%3Aopen+-repo%3Asyntax-tree%2Fideas+-repo%3Aremarkjs%2Fideas+-repo%3Arehypejs%2Fideas+-repo%3Aretextjs%2Fideas+-repo%3Aunifiedjs%2Fideas+-repo%3Avfile%2Fideas&type=Issues) when ignoring mdx-js.

### 🕴🏼 Hours / Rate

See unifiedjs/governance#20.

#### 🤓 Algorithm

*   Let `fee` be the payment processor fee (4.51%)
*   Let `annual` be the current OC Estimated Annual Budget ($26,409.00) reduced
    by `fee` ($25,217.95)
*   Let `balance` be the current OC Today’s Balance ($11,684.76) reduced by
    `fee` ($11,157.78)
*   Let `monthly` be `annual` divided by 12 ($2,101.50)
*   Let `balanceUse` be `balance` divided by 5 ($2,231.56)
*   Let `total` be the sum of `monthly` and `balanceUse` ($4,333.06)

> (note: on the open collective invoice I instead capped the hours to 108 at a rate of $40 to get an amount of $4,320)

### ✅ June

#### 📊 Numbers

*   **Commits**: [908](https://github.com/search?o=desc&q=author%3Awooorm+committer-date%3A%222019-06-01..2019-07-01%22&s=author-date&type=Commits)
*   **Issues and PRs**: [29](https://github.com/search?o=desc&q=author%3Awooorm+created%3A%222019-06-01..2019-07-01%22&s=created&type=Issues)
*   **Reviews**: [20](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-06-01..2019-07-01%22&s=created&type=Issues)

#### 🧹 Greenkeeping

Most time spent went into cleaning this garden 🌻 of 220+ collective projects.

* Updated under the collective: 210 (89 + 16 + 25 + 17 + 48 + 15)
* Not yet updated under the collective: 13 (1 `remarkjs/remark` + 5 @mdx-js + 7 @redotjs)

#### ✨ Highlights

* Created `.github` repos for unifiedjs, remarkjs, rehypejs, retextjs
* Rewrote [`syntax-tree/nlcst-emoji-modifier`](https://github.com/syntax-tree/nlcst-emoji-modifier)
* Rewrote [`remarkjs/remark-usage`](https://github.com/remarkjs/remark-usage) to use babel, support ESM
* Rewrote [`remarkjs/remark-validate-links`](https://github.com/remarkjs/remark-validate-links) to solve structural issues
* [`rehypejs/rehype-dom`](https://github.com/rehypejs/rehype-dom) and [`rehypejs/rehype-react`](https://github.com/rehypejs/rehype-react) are now governed by the collective
* Reviewed an [introduction to unified](https://github.com/unifiedjs/unifiedjs.github.io/pull/8) guide written by @Murderlon
* Most actionable issues are now solved

### 🗓 July

In July I want to:

* Publish the changes under @remarkjs
* Improve security in the collective
* Write more policies (including security)
* Update health files in @mdx-js
* Work on [org tooling](https://github.com/unifiedjs/rfcs/pull/1)
* Find more sponsors

### 🚀 Future

*   There are some problems with rehype formatting and minifying that are non-trivial to solve
*   Add a layer on top of unified and vfile that makes it easier to work with multiple files (uniflow?)
*   Restarting micromark
