### PR TITLE
Add differentiation between mergers, releasers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,15 +249,15 @@ The **rehype team** is an **[organization][]** team responsible for
 *   John Otander
     ([**@johno**](https://github.com/johno))
     &lt;johnotander@gmail.com>
-*   Keith McKnight
-    ([**@kmck**](https://github.com/kmck))
-    &lt;keith@mcknig.ht>
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
 
 ##### Releasers
 
+*   Keith McKnight
+    ([**@kmck**](https://github.com/kmck))
+    &lt;keith@mcknig.ht>
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
@@ -422,15 +422,15 @@ The **syntax tree team** is an **[organization][]** team responsible for
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
-*   Keith McKnight
-    ([**@kmck**](https://github.com/kmck))
-    &lt;keith@mcknig.ht>
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
 
 ##### Releasers
 
+*   Keith McKnight
+    ([**@kmck**](https://github.com/kmck))
+    &lt;keith@mcknig.ht>
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>

--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,9 @@ The **unified team** is an **[organization][]** team responsible for
 *   John Otander
     ([**@johno**](https://github.com/johno))
     &lt;johnotander@gmail.com>
+*   Junyoung Choi
+    ([**@Rokt33r**](https://github.com/Rokt33r))
+    &lt;fluke8259@gmail.com>
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
@@ -448,6 +451,9 @@ The **vfile team** is an **[organization][]** team responsible for
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
+*   Junyoung Choi
+    ([**@Rokt33r**](https://github.com/Rokt33r))
+    &lt;fluke8259@gmail.com>
 
 ##### Releasers
 

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,8 @@ The **unified team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
@@ -159,6 +161,9 @@ The **unified team** is an **[organization][]** team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
+
+##### Releasers
+
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
@@ -183,15 +188,14 @@ The **remark team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Jonathan Haines
     ([**@BarryThePenguin**](https://github.com/BarryThePenguin))
     &lt;jonno.haines@gmail.com>
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
-*   John Otander
-    ([**@johno**](https://github.com/johno))
-    &lt;johnotander@gmail.com>
 *   Junyoung Choi
     ([**@Rokt33r**](https://github.com/Rokt33r))
     &lt;fluke8259@gmail.com>
@@ -204,16 +208,22 @@ The **remark team** is an **[organization][]** team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
-*   Titus Wormer
-    ([**@wooorm**](https://github.com/wooorm))
-    &lt;tituswormer@gmail.com>
-    (**lead**)
 *   Victor Felder
     ([**@vhf**](https://github.com/vhf))
     &lt;victor@draft.li>
 *   Zeke Sikelianos
     ([**@zeke**](https://github.com/zeke))
     &lt;zeke@sikelianos.com>
+
+##### Releasers
+
+*   John Otander
+    ([**@johno**](https://github.com/johno))
+    &lt;johnotander@gmail.com>
+*   Titus Wormer
+    ([**@wooorm**](https://github.com/wooorm))
+    &lt;tituswormer@gmail.com>
+    (**lead**)
 
 #### Emeriti
 
@@ -231,6 +241,8 @@ The **rehype team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
@@ -243,6 +255,9 @@ The **rehype team** is an **[organization][]** team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
+
+##### Releasers
+
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
@@ -261,9 +276,14 @@ The **retext team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
+
+##### Releasers
+
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
@@ -282,6 +302,12 @@ The **redot team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
+None.
+
+##### Releasers
+
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
@@ -297,12 +323,17 @@ The **mdx team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Christopher Biscardi
     ([**@ChristopherBiscardi**](https://github.com/ChristopherBiscardi))
     &lt;chris@christopherbiscardi.com>
 *   Jarred Sumner
     ([**@Jarred-Sumner**](https://github.com/Jarred-Sumner))
     &lt;jarred@jarredsumner.com>
+
+##### Releasers
+
 *   John Otander
     ([**@johno**](https://github.com/johno))
     &lt;johnotander@gmail.com>
@@ -345,6 +376,8 @@ The **micromark team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   John Otander
     ([**@johno**](https://github.com/johno))
     &lt;johnotander@gmail.com>
@@ -354,6 +387,9 @@ The **micromark team** is an **[organization][]** team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
+
+##### Releasers
+
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
@@ -378,6 +414,8 @@ The **syntax tree team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Jonathan Haines
     ([**@BarryThePenguin**](https://github.com/BarryThePenguin))
     &lt;jonno.haines@gmail.com>
@@ -390,6 +428,9 @@ The **syntax tree team** is an **[organization][]** team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
+
+##### Releasers
+
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
@@ -402,9 +443,14 @@ The **vfile team** is an **[organization][]** team responsible for
 
 #### Members
 
+##### Mergers
+
 *   Christian Murphy
     ([**@christianmurphy**](https://github.com/christianmurphy))
     &lt;christian.murphy.42@gmail.com>
+
+##### Releasers
+
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>


### PR DESCRIPTION
Hi folks! 👋

I just implemented [`npm-tools`](https://github.com/unifiedjs/npm-tools) to automate the access and permissions to the packages under the collective on npm. It’s now trivial to grant read or write access.

A while back, we defined mergers and releasers, but the latter was never implemented because it was such an intensive task (400+ packages 😬).

So the question is: who wants to be a releaser?
- Mergers have write access on GitHub, but read access on npm.
- Releasers have admin access on GitHub and write access (they can publish packages) on npm.

It would be nice if there are at least two releasers per org. But also not everyone needs these permissions!

If you’d like to change your role (see [rendered version](https://github.com/unifiedjs/governance/blob/releasers/readme.md)), please respond below with the orgs and the respective desired roles!

/CC @christianmurphy, @johno, @Murderlon, @BarryThePenguin, @Rokt33r, @kmck, @fazouane-marouane, @vhf, @zeke, @ChristopherBiscardi, @Jarred-Sumner, @silvenon, @timneutkens