### PR TITLE
Add invoice for @wooorm

### DIFF
--- a/invoices/2019-07-31-wooorm.md
+++ b/invoices/2019-07-31-wooorm.md
@@ -1,0 +1,17 @@
+# Invoice: unified collective
+
+*   **Date**: 2019-07-31
+*   **Person**: Titus Wormer ([**@wooorm**](https://github.com/wooorm))
+*   **Rate**: $40/hr (non-profit, open source discount)
+
+## Items
+
+| Item               | Description                    | Hours | Total         |
+| ------------------ | ------------------------------ | ----- | ------------- |
+| unified collective | Development and support (June) | *108* | **$4,320.00** |
+
+* * *
+
+*   **Commits**: [346](https://github.com/search?o=desc&q=author%3Awooorm+committer-date%3A%222019-07-01..2019-08-01%22&s=author-date&type=Commits)
+*   **Issues and PRs**: [16](https://github.com/search?o=desc&q=author%3Awooorm+created%3A%222019-07-01..2019-08-01%22&s=created&type=Issues)
+*   **Reviews**: [24](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-07-01..2019-08-01%22&s=created&type=Issues)

--- a/invoices/2019-07-31-wooorm.md
+++ b/invoices/2019-07-31-wooorm.md
@@ -8,7 +8,7 @@
 
 | Item               | Description                    | Hours | Total         |
 | ------------------ | ------------------------------ | ----- | ------------- |
-| unified collective | Development and support (June) | *108* | **$4,320.00** |
+| unified collective | Development and support (July) | *108* | **$4,320.00** |
 
 * * *
 


### PR DESCRIPTION
Hi friends!  👋

This month (July 1 to July 31) was my third month of full time OSS!  Pretty cool! 💪  Thanks to all the sponsors and everyone that helps!  ❤️

Here’s what I did:
*   work on a major release of @remarkjs and its plugins, making the whole collective **stable** for the first time in years
*   wrote security sections for potentially dangerous projects (syntax-tree, remark, and rehype) and added [`security.md`](https://github.com/unifiedjs/.github/blob/master/support.md) policies to all health repos
*   automated access and security with [`github-tools`](https://github.com/unifiedjs/github-tools) and [`npm-tools`](https://github.com/unifiedjs/npm-tools)
*   Reviewed inactive team members ([`unifiedjs/governance#23`](https://github.com/unifiedjs/governance/issues/23))
*   I’m in contact with two slightly-more-than-potential sponsors

The number of big open issues is decreasing. There’s about [32 issues left](https://github.com/search?q=user%3Amicromark+user%3Aremarkjs+user%3Arehypejs+user%3Aretextjs+user%3Aunifiedjs+user%3Asyntax-tree+user%3Avfile+is%3Aopen+-repo%3Asyntax-tree%2Fideas+-repo%3Aremarkjs%2Fideas+-repo%3Arehypejs%2Fideas+-repo%3Aretextjs%2Fideas+-repo%3Aunifiedjs%2Fideas+-repo%3Avfile%2Fideas&type=Issues) when ignoring mdx-js.

### 🕴🏼 Hours / Rate

See unifiedjs/governance#20.

#### 🤓 Algorithm

*   Let `fee` be the payment processor fee (4.51%)
*   Let `annual` be the current OC Estimated Annual Budget ($26,431.31) reduced
    by `fee` ($25,239.36)
*   Let `balance` be the current OC Today’s Balance ($9,406.61) reduced by
    `fee` ($8,982.37)
*   Let `monthly` be `annual` divided by 12 ($2,103.28)
*   Let `balanceUse` be `balance` divided by 4 ($2,245.59)
*   Let `total` be the sum of `monthly` and `balanceUse` ($4,348.87)

> (note: on the open collective invoice I instead capped the hours to 108 at a rate of $40 to get an amount of $4,320)

### ✅ July

#### 📊 Numbers

*   **Commits**: [346](https://github.com/search?o=desc&q=author%3Awooorm+committer-date%3A%222019-07-01..2019-08-01%22&s=author-date&type=Commits)
*   **Issues and PRs**: [16](https://github.com/search?o=desc&q=author%3Awooorm+created%3A%222019-07-01..2019-08-01%22&s=created&type=Issues)
*   **Reviews**: [24](https://github.com/search?o=desc&q=reviewed-by%3Awooorm+created%3A%222019-07-01..2019-08-01%22&s=created&type=Issues)

#### 🌻 Greenkeeping

The whole collective is now clean!  vfile, syntax-tree, remarkjs, rehypejs, retextjs, unifiedjs, etc!

#### 👮🏽‍♀️ Security

We have security policies.  I tested a bunch of projects for XSS securities, fixed a few, and everything is pretty secure now (I don’t want to jinx).  GitHub and npm access is automated.  I’m really happy about this!

### 🗓 August

In August I want to:

* Find more sponsors
* Finish our governance docs to reflect the updates in the last three months
* Work on making the collective more approachable (contributor team, website?)
* Be a bit less stressed about OSS

### 🚀 Future

*   Make org tools usable for others and more usable to us: add labels, properly pull in humans and structure, pluggable
*   There are some problems with rehype formatting and minifying that are non-trivial to solve
*   Add a layer on top of unified and vfile that makes it easier to work with multiple files (uniflow?)
*   Restarting micromark
