### PR TITLE
Add structured data for humans, teams

### DIFF
--- a/data/humans.yml
+++ b/data/humans.yml
@@ -76,7 +76,7 @@
   github: sobolevn
   npm: sobolevn
 - name: Olivia Hugger
-  email: liv@fastmail.com
+  email: mokou@posteo.de
   github: komaeda
   npm: komaeda
 - name: Richard Littauer

--- a/data/humans.yml
+++ b/data/humans.yml
@@ -1,0 +1,109 @@
+- name: Adam Morse
+  email: hi@mrmrs.cc
+  url: https://mrmrs.cc
+  github: mrmrs
+  npm: mrmrs
+- name: Ahmad Awais
+  email: me@AhmadAwais.com
+  github: ahmadawais
+  npm: mrahmadawais
+- name: Brent Jackson
+  email: jxnblk@gmail.com
+  url: https://jxnblk.com
+  github: jxnblk
+  npm: jxnblk
+- name: Christian Murphy
+  email: christian.murphy.42@gmail.com
+  github: ChristianMurphy
+  npm: christianmurphy
+- name: Christopher Biscardi
+  email: chris@christopherbiscardi.com
+  url: https://www.christopherbiscardi.com
+  github: ChristopherBiscardi
+  npm: biscarch
+- name: Guillermo Rauch
+  email: rauchg@gmail.com
+  url: https://rauchg.com
+  github: rauchg
+  npm: rauchg
+- name: Jarred Sumner
+  email: jarred@jarredsumner.com
+  url: https://jarredsumner.com
+  github: Jarred-Sumner
+- name: Jessica Stokes
+  email: hello@jessicastokes.net
+  github: ticky
+  npm: ticky
+- name: John Otander
+  email: johnotander@gmail.com
+  url: http://johnotander.com
+  github: johno
+  npm: johno
+- name: Jonathan Haines
+  email: jonno.haines@gmail.com
+  github: BarryThePenguin
+  npm: barrythepenguin
+- name: Junyoung Choi
+  email: fluke8259@gmail.com
+  url: https://rokt33r.github.io
+  github: Rokt33r
+  npm: rokt33r
+- name: Keith McKnight
+  email: keith@mcknig.ht
+  url: https://keith.mcknig.ht
+  github: kmck
+  npm: kmck
+- name: Marouane Fazouane
+  email: fazouanem3@gmail.com
+  github: fazouane-marouane
+  npm: fazouane-marouane
+- name: Matija Marohnić
+  email: matija.marohnic@gmail.com
+  url: https://silvenon.com
+  github: silvenon
+  npm: silvenon
+- name: Merlijn Vos
+  email: merlijn@soverin.net
+  github: Murderlon
+  npm: murderlon
+- name: Mudit Ameta
+  email: zeusdeux@gmail.com
+  url: https://mudit.xyz
+  github: zeusdeux
+  npm: zeusdeux
+- name: Nikita Sobolev
+  email: mail@sobolevn.me
+  github: sobolevn
+  npm: sobolevn
+- name: Olivia Hugger
+  email: liv@fastmail.com
+  github: komaeda
+  npm: komaeda
+- name: Richard Littauer
+  email: richard@maintainer.io
+  url: https://burntfen.com
+  github: RichardLitt
+  npm: richardlitt
+- name: Stephan Schneider
+  email: stephanschndr@gmail.com
+  github: zcei
+  npm: zcei
+- name: Tim Neutkens
+  email: tim@zeit.co
+  github: timneutkens
+  npm: timneutkens
+- name: Titus Wormer
+  email: tituswormer@gmail.com
+  url: https://wooorm.com
+  github: wooorm
+  npm: wooorm
+- name: Victor Felder
+  email: victor@draft.li
+  url: https://draft.li
+  github: vhf
+  npm: vhf
+- name: Zeke Sikelianos
+  email: zeke@sikelianos.com
+  url: http://zeke.sikelianos.com
+  github: zeke
+  npm: zeke

--- a/data/teams.yml
+++ b/data/teams.yml
@@ -1,0 +1,100 @@
+- name: core
+  collective: true
+  humans:
+    ChristianMurphy: member
+    johno: member
+    Murderlon: member
+    wooorm: member
+    RichardLitt: emeritus
+    zcei: emeritus
+- name: moderation
+  collective: true
+  humans:
+    komaeda: member
+    RichardLitt: member
+- name: unified
+  lead: wooorm
+  humans:
+    wooorm: releaser
+    ChristianMurphy: merger
+    johno: merger
+    Murderlon: merger
+    Rokt33r: merger
+    vhf: emeritus
+    zcei: emeritus
+    zeusdeux: emeritus
+- name: remark
+  lead: wooorm
+  humans:
+    johno: releaser
+    wooorm: releaser
+    BarryThePenguin: merger
+    ChristianMurphy: merger
+    fazouane-marouane: merger
+    kmck: merger
+    Murderlon: merger
+    Rokt33r: merger
+    vhf: merger
+    zeke: merger
+    sobolevn: emeritus
+    zeusdeux: emeritus
+- name: rehype
+  lead: wooorm
+  humans:
+    wooorm: releaser
+    kmck: releaser
+    ChristianMurphy: merger
+    johno: merger
+    Murderlon: merger
+    vhf: emeritus
+- name: retext
+  lead: wooorm
+  humans:
+    wooorm: releaser
+    Murderlon: merger
+    RichardLitt: emeritus
+- name: redot
+  lead: ChristianMurphy
+  humans:
+    ChristianMurphy: releaser
+    wooorm: releaser
+- name: micromark
+  lead: wooorm
+  humans:
+    wooorm: releaser
+    fazouane-marouane: merger
+    johno: merger
+    Murderlon: merger
+    vhf: emeritus
+    zcei: emeritus
+    zeusdeux: emeritus
+- name: mdx
+  lead: johno
+  humans:
+    johno: releaser
+    silvenon: releaser
+    timneutkens: releaser
+    wooorm: releaser
+    ChristopherBiscardi: merger
+    Jarred-Sumner: merger
+    ahmadawais: emeritus
+    jxnblk: emeritus
+    mrmrs: emeritus
+    rauchg: emeritus
+    ticky: emeritus
+    zcei: emeritus
+- name: vfile
+  lead: wooorm
+  humans:
+    wooorm: releaser
+    ChristianMurphy: merger
+    Rokt33r: merger
+    komaeda: emeritus
+- name: syntax tree
+  lead: wooorm
+  humans:
+    wooorm: releaser
+    kmck: releaser
+    BarryThePenguin: merger
+    ChristianMurphy: merger
+    Murderlon: merger

--- a/package.json
+++ b/package.json
@@ -12,16 +12,35 @@
     "Titus Wormer <tituswormer@gmail.com> (wooorm.com)"
   ],
   "devDependencies": {
+    "js-yaml": "^3.0.0",
+    "mdast-comment-marker": "^1.0.0",
+    "mdast-zone": "^3.0.0",
+    "prettier": "^1.0.0",
     "remark-cli": "^7.0.0",
-    "remark-preset-wooorm": "^6.0.0"
+    "remark-preset-wooorm": "^6.0.0",
+    "unist-builder": "^1.0.0",
+    "xo": "^0.24.0"
   },
   "scripts": {
-    "format": "remark . -qfo",
+    "format": "remark . -qfo && prettier --write \"**/*.js\" && xo --fix",
     "test": "npm run format"
+  },
+  "prettier": {
+    "tabWidth": 2,
+    "useTabs": false,
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "semi": false,
+    "trailingComma": "none"
+  },
+  "xo": {
+    "prettier": true,
+    "esnext": false
   },
   "remarkConfig": {
     "plugins": [
-      "preset-wooorm"
+      "preset-wooorm",
+      "./script/list-of-humans"
     ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -148,12 +148,21 @@ individuals should additionally be classified as mergers, but not releasers.
 The **unified team** is an **[organization][]** team responsible for
 [**@unifiedjs**](https://github.com/unifiedjs).
 
+<!--humans start team=unified shift=3-->
+
 #### Members
+
+##### Releasers
+
+*   Titus Wormer
+    ([**@wooorm**](https://github.com/wooorm))
+    &lt;tituswormer@gmail.com>
+    (**lead**)
 
 ##### Mergers
 
 *   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
     &lt;christian.murphy.42@gmail.com>
 *   John Otander
     ([**@johno**](https://github.com/johno))
@@ -164,13 +173,6 @@ The **unified team** is an **[organization][]** team responsible for
 *   Merlijn Vos
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
-
-##### Releasers
-
-*   Titus Wormer
-    ([**@wooorm**](https://github.com/wooorm))
-    &lt;tituswormer@gmail.com>
-    (**lead**)
 
 #### Emeriti
 
@@ -184,21 +186,35 @@ The **unified team** is an **[organization][]** team responsible for
     ([**@vhf**](https://github.com/vhf))
     &lt;victor@draft.li>
 
+<!--humans end-->
+
 ### remark team
 
 The **remark team** is an **[organization][]** team responsible for
 [**@remarkjs**](https://github.com/remarkjs).
 
+<!--humans start team=remark shift=3-->
+
 #### Members
+
+##### Releasers
+
+*   John Otander
+    ([**@johno**](https://github.com/johno))
+    &lt;johnotander@gmail.com>
+*   Titus Wormer
+    ([**@wooorm**](https://github.com/wooorm))
+    &lt;tituswormer@gmail.com>
+    (**lead**)
 
 ##### Mergers
 
+*   Christian Murphy
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
+    &lt;christian.murphy.42@gmail.com>
 *   Jonathan Haines
     ([**@BarryThePenguin**](https://github.com/BarryThePenguin))
     &lt;jonno.haines@gmail.com>
-*   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
-    &lt;christian.murphy.42@gmail.com>
 *   Junyoung Choi
     ([**@Rokt33r**](https://github.com/Rokt33r))
     &lt;fluke8259@gmail.com>
@@ -218,16 +234,6 @@ The **remark team** is an **[organization][]** team responsible for
     ([**@zeke**](https://github.com/zeke))
     &lt;zeke@sikelianos.com>
 
-##### Releasers
-
-*   John Otander
-    ([**@johno**](https://github.com/johno))
-    &lt;johnotander@gmail.com>
-*   Titus Wormer
-    ([**@wooorm**](https://github.com/wooorm))
-    &lt;tituswormer@gmail.com>
-    (**lead**)
-
 #### Emeriti
 
 *   Mudit Ameta
@@ -237,24 +243,16 @@ The **remark team** is an **[organization][]** team responsible for
     ([**@sobolevn**](https://github.com/sobolevn))
     &lt;mail@sobolevn.me>
 
+<!--humans end-->
+
 ### rehype team
 
 The **rehype team** is an **[organization][]** team responsible for
 [**@rehypejs**](https://github.com/rehypejs).
 
+<!--humans start team=rehype shift=3-->
+
 #### Members
-
-##### Mergers
-
-*   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
-    &lt;christian.murphy.42@gmail.com>
-*   John Otander
-    ([**@johno**](https://github.com/johno))
-    &lt;johnotander@gmail.com>
-*   Merlijn Vos
-    ([**@Murderlon**](https://github.com/Murderlon))
-    &lt;merlijn@soverin.net>
 
 ##### Releasers
 
@@ -266,18 +264,41 @@ The **rehype team** is an **[organization][]** team responsible for
     &lt;tituswormer@gmail.com>
     (**lead**)
 
+##### Mergers
+
+*   Christian Murphy
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
+    &lt;christian.murphy.42@gmail.com>
+*   John Otander
+    ([**@johno**](https://github.com/johno))
+    &lt;johnotander@gmail.com>
+*   Merlijn Vos
+    ([**@Murderlon**](https://github.com/Murderlon))
+    &lt;merlijn@soverin.net>
+
 #### Emeriti
 
 *   Victor Felder
     ([**@vhf**](https://github.com/vhf))
     &lt;victor@draft.li>
 
+<!--humans end-->
+
 ### retext team
 
 The **retext team** is an **[organization][]** team responsible for
 [**@retextjs**](https://github.com/retextjs).
 
+<!--humans start team=retext shift=3-->
+
 #### Members
+
+##### Releasers
+
+*   Titus Wormer
+    ([**@wooorm**](https://github.com/wooorm))
+    &lt;tituswormer@gmail.com>
+    (**lead**)
 
 ##### Mergers
 
@@ -285,55 +306,47 @@ The **retext team** is an **[organization][]** team responsible for
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
 
-##### Releasers
-
-*   Titus Wormer
-    ([**@wooorm**](https://github.com/wooorm))
-    &lt;tituswormer@gmail.com>
-    (**lead**)
-
 #### Emeriti
 
 *   Richard Littauer
     ([**@RichardLitt**](https://github.com/RichardLitt))
     &lt;richard@maintainer.io>
 
+<!--humans end-->
+
 ### redot team
 
 The **redot team** is an **[organization][]** team responsible for
 [**@redotjs**](https://github.com/redotjs).
 
+<!--humans start team=redot shift=3-->
+
 #### Members
-
-##### Mergers
-
-None.
 
 ##### Releasers
 
 *   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
     &lt;christian.murphy.42@gmail.com>
     (**lead**)
 *   Titus Wormer
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
 
+##### Mergers
+
+None.
+
+<!--humans end-->
+
 ### mdx team
 
 The **mdx team** is an **[organization][]** team responsible for
 [**@mdx-js**](https://github.com/mdx-js).
 
+<!--humans start team=mdx shift=3-->
+
 #### Members
-
-##### Mergers
-
-*   Christopher Biscardi
-    ([**@ChristopherBiscardi**](https://github.com/ChristopherBiscardi))
-    &lt;chris@christopherbiscardi.com>
-*   Jarred Sumner
-    ([**@Jarred-Sumner**](https://github.com/Jarred-Sumner))
-    &lt;jarred@jarredsumner.com>
 
 ##### Releasers
 
@@ -351,33 +364,53 @@ The **mdx team** is an **[organization][]** team responsible for
     ([**@wooorm**](https://github.com/wooorm))
     &lt;tituswormer@gmail.com>
 
+##### Mergers
+
+*   Christopher Biscardi
+    ([**@ChristopherBiscardi**](https://github.com/ChristopherBiscardi))
+    &lt;chris@christopherbiscardi.com>
+*   Jarred Sumner
+    ([**@Jarred-Sumner**](https://github.com/Jarred-Sumner))
+    &lt;jarred@jarredsumner.com>
+
 #### Emeriti
 
 *   Adam Morse
     ([**@mrmrs**](https://github.com/mrmrs))
     &lt;hi@mrmrs.cc>
+*   Ahmad Awais
+    ([**@ahmadawais**](https://github.com/ahmadawais))
+    &lt;me@AhmadAwais.com>
 *   Brent Jackson
     ([**@jxnblk**](https://github.com/jxnblk))
     &lt;jxnblk@gmail.com>
 *   Guillermo Rauch
     ([**@rauchg**](https://github.com/rauchg))
     &lt;rauchg@gmail.com>
-*   Mudit Ameta
-    ([**@zeusdeux**](https://github.com/zeusdeux))
-    &lt;zeusdeux@gmail.com>
-*   Stephan Schneider
-    ([**@zcei**](https://github.com/zcei))
-    &lt;stephanschndr@gmail.com>
 *   Jessica Stokes
     ([**@ticky**](https://github.com/ticky))
     &lt;hello@jessicastokes.net>
+*   Stephan Schneider
+    ([**@zcei**](https://github.com/zcei))
+    &lt;stephanschndr@gmail.com>
+
+<!--humans end-->
 
 ### micromark team
 
 The **micromark team** is an **[organization][]** team responsible for
 [**@micromark**](https://github.com/micromark).
 
+<!--humans start team=micromark shift=3-->
+
 #### Members
+
+##### Releasers
+
+*   Titus Wormer
+    ([**@wooorm**](https://github.com/wooorm))
+    &lt;tituswormer@gmail.com>
+    (**lead**)
 
 ##### Mergers
 
@@ -391,13 +424,6 @@ The **micromark team** is an **[organization][]** team responsible for
     ([**@Murderlon**](https://github.com/Murderlon))
     &lt;merlijn@soverin.net>
 
-##### Releasers
-
-*   Titus Wormer
-    ([**@wooorm**](https://github.com/wooorm))
-    &lt;tituswormer@gmail.com>
-    (**lead**)
-
 #### Emeriti
 
 *   Mudit Ameta
@@ -410,24 +436,16 @@ The **micromark team** is an **[organization][]** team responsible for
     ([**@vhf**](https://github.com/vhf))
     &lt;victor@draft.li>
 
+<!--humans end-->
+
 ### syntax tree team
 
 The **syntax tree team** is an **[organization][]** team responsible for
 [**@syntax-tree**](https://github.com/syntax-tree).
 
+<!--humans start team="syntax tree" shift=3-->
+
 #### Members
-
-##### Mergers
-
-*   Jonathan Haines
-    ([**@BarryThePenguin**](https://github.com/BarryThePenguin))
-    &lt;jonno.haines@gmail.com>
-*   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
-    &lt;christian.murphy.42@gmail.com>
-*   Merlijn Vos
-    ([**@Murderlon**](https://github.com/Murderlon))
-    &lt;merlijn@soverin.net>
 
 ##### Releasers
 
@@ -439,21 +457,28 @@ The **syntax tree team** is an **[organization][]** team responsible for
     &lt;tituswormer@gmail.com>
     (**lead**)
 
+##### Mergers
+
+*   Christian Murphy
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
+    &lt;christian.murphy.42@gmail.com>
+*   Jonathan Haines
+    ([**@BarryThePenguin**](https://github.com/BarryThePenguin))
+    &lt;jonno.haines@gmail.com>
+*   Merlijn Vos
+    ([**@Murderlon**](https://github.com/Murderlon))
+    &lt;merlijn@soverin.net>
+
+<!--humans end-->
+
 ### vfile team
 
 The **vfile team** is an **[organization][]** team responsible for
 [**@vfile**](https://github.com/vfile).
 
+<!--humans start team=vfile shift=3-->
+
 #### Members
-
-##### Mergers
-
-*   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
-    &lt;christian.murphy.42@gmail.com>
-*   Junyoung Choi
-    ([**@Rokt33r**](https://github.com/Rokt33r))
-    &lt;fluke8259@gmail.com>
 
 ##### Releasers
 
@@ -462,11 +487,22 @@ The **vfile team** is an **[organization][]** team responsible for
     &lt;tituswormer@gmail.com>
     (**lead**)
 
+##### Mergers
+
+*   Christian Murphy
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
+    &lt;christian.murphy.42@gmail.com>
+*   Junyoung Choi
+    ([**@Rokt33r**](https://github.com/Rokt33r))
+    &lt;fluke8259@gmail.com>
+
 #### Emeriti
 
 *   Olivia Hugger
     ([**@komaeda**](https://github.com/komaeda))
     &lt;liv@fastmail.com>
+
+<!--humans end-->
 
 ## Collective teams
 
@@ -505,10 +541,12 @@ They additionally:
     Emeriti may request that the their status is restored.
 *   **Offboard team members**.
 
+<!--humans start team=core shift=3-->
+
 #### Members
 
 *   Christian Murphy
-    ([**@christianmurphy**](https://github.com/christianmurphy))
+    ([**@ChristianMurphy**](https://github.com/ChristianMurphy))
     &lt;christian.murphy.42@gmail.com>
 *   John Otander
     ([**@johno**](https://github.com/johno))
@@ -529,12 +567,16 @@ They additionally:
     ([**@zcei**](https://github.com/zcei))
     &lt;stephanschndr@gmail.com>
 
+<!--humans end-->
+
 ### Moderation team
 
 The **moderation team** is a **[collective][]** team responsible for enforcing
 the code of conduct.
 This team does not have a leader and, to limit conflicts of interest, **should**
 not include **[core team][core]** members.
+
+<!--humans start team=moderation shift=3-->
 
 #### Members
 
@@ -544,6 +586,8 @@ not include **[core team][core]** members.
 *   Richard Littauer
     ([**@RichardLitt**](https://github.com/RichardLitt))
     &lt;richard@maintainer.io>
+
+<!--humans end-->
 
 ## Glossary
 

--- a/script/list-of-humans.js
+++ b/script/list-of-humans.js
@@ -1,0 +1,106 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var yaml = require('js-yaml')
+var zone = require('mdast-zone')
+var marker = require('mdast-comment-marker')
+var u = require('unist-builder')
+
+var humans = yaml.safeLoad(fs.readFileSync(path.join('data', 'humans.yml')))
+var teams = yaml.safeLoad(fs.readFileSync(path.join('data', 'teams.yml')))
+
+module.exports = listOfHumans
+
+function listOfHumans() {
+  return transform
+
+  function transform(tree, file) {
+    zone(tree, 'humans', onzone)
+
+    function onzone(start, nodes, end) {
+      var params = marker(start).parameters
+      var shift = params.shift || 0
+      var name = params.team
+
+      if (!name) {
+        file.fail('Missing team attribute in humans marker', start)
+      }
+
+      var team = teams.find(s => s.name === name)
+
+      if (!team) {
+        file.fail('Missing definition for team `' + name + '`', start)
+      }
+
+      var content = [u('heading', {depth: 1 + shift}, [u('text', 'Members')])]
+
+      var byRole = Object.keys(team.humans).reduce((all, h) => {
+        var role = team.humans[h]
+        all[role] = (all[role] || []).concat(h)
+        return all
+      }, {})
+
+      if (team.collective) {
+        content.push(
+          byRole.member
+            ? list(team, byRole.member)
+            : u('paragraph', [u('text', 'None.')])
+        )
+      } else {
+        content.push(
+          u('heading', {depth: 2 + shift}, [u('text', 'Releasers')]),
+          byRole.releaser
+            ? list(team, byRole.releaser)
+            : u('paragraph', [u('text', 'None.')]),
+          u('heading', {depth: 2 + shift}, [u('text', 'Mergers')]),
+          byRole.merger
+            ? list(team, byRole.merger)
+            : u('paragraph', [u('text', 'None.')])
+        )
+      }
+
+      if (byRole.emeritus) {
+        content.push(
+          u('heading', {depth: 1 + shift}, [u('text', 'Emeriti')]),
+          list(team, byRole.emeritus)
+        )
+      }
+
+      return [start].concat(content, end)
+    }
+  }
+}
+
+function list(team, users) {
+  return u(
+    'list',
+    {ordered: false},
+    users
+      .map(github => humans.find(p => p.github === github))
+      .sort((a, b) => {
+        return a.name.localeCompare(b.name)
+      })
+      .map(function(human) {
+        var content = [
+          u('text', human.name + '\n('),
+          u('link', {url: 'https://github.com/' + human.github}, [
+            u('strong', [u('text', '@' + human.github)])
+          ]),
+          u('text', ')\n<'),
+          u('text', human.email),
+          u('text', '>')
+        ]
+
+        if (human.github === team.lead) {
+          content.push(
+            u('text', '\n('),
+            u('strong', [u('text', 'lead')]),
+            u('text', ')')
+          )
+        }
+
+        return u('listItem', [u('paragraph', content)])
+      })
+  )
+}


### PR DESCRIPTION
Previously, who was a member and in what role was maintained in prose
(in `readme.md`). This makes the data structured and available in `data` as `humans.yml`
and `teams.yml`. This information is used to generate the readme from and can be used
by other tools.
